### PR TITLE
Use s3 docker cache instead of GHA for wasm

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Configure AWS credentials for ECR access
         uses: "aws-actions/configure-aws-credentials@v1"
         with:
-          # Reusing the CiLambdaWorkersDeployment IAM user for now
+          # GithubCIUser
           aws-access-key-id: "${{ vars.AWS_ACCESS_KEY_ID }}"
           aws-region: us-east-1
           aws-secret-access-key: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -6,6 +6,7 @@ env:
   GITLAB_REGISTRY: registry.avcd.cz
   GITLAB_PROJECT: opendesign/open-design-engine/wasm
   GITLAB_USERNAME: registry
+  DOCKER_CACHE: "type=s3,region=us-east-1,bucket=opendesign-pc-ceros-dev-github-ci,prefix=open-design-engine/wasm/"
 
 jobs:
   wasm:
@@ -19,6 +20,13 @@ jobs:
           submodules: true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      - name: Configure AWS credentials for ECR access
+        uses: "aws-actions/configure-aws-credentials@v1"
+        with:
+          # GithubCIUser
+          aws-access-key-id: "${{ vars.AWS_ACCESS_KEY_ID }}"
+          aws-region: us-east-1
+          aws-secret-access-key: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
       - name: Login to Gitlab Container Registry
         uses: docker/login-action@v2
         with:
@@ -56,22 +64,34 @@ jobs:
           file: ode-animation-prototype/docker/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            ${{ env.DOCKER_CACHE }},name=main
+            ${{ env.DOCKER_CACHE }},name=${{ github.ref_name }}
+          cache-to: |
+            ${{ env.DOCKER_CACHE }},name=${{ github.ref_name }},mode=max
+      - name: Cache base image in main
+        uses: docker/build-push-action@v3
+        if: ${{ github.ref_name == 'main' }}
+        with:
+          context: .
+          cache-from: |
+            ${{ env.DOCKER_CACHE }},name=${{ github.ref_name }}
+          cache-to: |
+            ${{ env.DOCKER_CACHE }},name=main,mode=max
       - name: Adding output tags to summary
         run: |
           echo "Main docker image: ${{ fromJSON(steps.meta.outputs.json).tags[1] }}" >> $GITHUB_STEP_SUMMARY
       - name: Build WASM and publish
-        run: docker run -v $(pwd):/src -e NPM_TOKEN=$NPM_TOKEN $BASE_IMAGE_CACHE bash ode-animation-prototype/wasm-build.sh --publish
+        run: docker run -v $(pwd):/src -e NPM_TOKEN=$NPM_TOKEN $BASE_IMAGE_TAG bash ode-animation-prototype/wasm-build.sh --publish
         if: github.ref == 'refs/heads/main'
         env:
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}
-          BASE_IMAGE_CACHE: "${{ fromJSON(steps.meta.outputs.json).tags[1] }}"
+          BASE_IMAGE_TAG: "${{ fromJSON(steps.meta.outputs.json).tags[1] }}"
       - name: Build WASM
-        run: docker run -v $(pwd):/src -e NPM_TOKEN=$NPM_TOKEN $BASE_IMAGE_CACHE bash ode-animation-prototype/wasm-build.sh
+        run: docker run -v $(pwd):/src -e NPM_TOKEN=$NPM_TOKEN $BASE_IMAGE_TAG bash ode-animation-prototype/wasm-build.sh
         if: github.ref != 'refs/heads/main'
         env:
-          BASE_IMAGE_CACHE: "${{ fromJSON(steps.meta.outputs.json).tags[1] }}"
+          BASE_IMAGE_TAG: "${{ fromJSON(steps.meta.outputs.json).tags[1] }}"
       - name: WASM artifacts
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This should be pretty much equivalent to GHA, but with no 10GiB limit