### PR TITLE
Remove the custom personal access token from CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,9 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          # Personal token with read-only access to liboctopus and open-design-text-renderer
-          # https://github.com/organizations/opendesigndev/settings/personal-access-tokens/39049
-          token: ${{ secrets.ODE_REPOS_TOKEN }}
           submodules: true
       - uses: ./.github/actions/determine-version
         id: npm-version

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,9 +17,6 @@ jobs:
         run: echo "PATH=/opt/homebrew/bin:$PATH" >> $GITHUB_ENV
       - uses: actions/checkout@v3
         with:
-          # Personal token with read-only access to liboctopus and open-design-text-renderer
-          # https://github.com/organizations/opendesigndev/settings/personal-access-tokens/39049
-          token: ${{ secrets.ODE_REPOS_TOKEN }}
           submodules: true
 
       - name: Get project variables

--- a/.github/workflows/publish-source.yml
+++ b/.github/workflows/publish-source.yml
@@ -8,9 +8,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          # Personal token with read-only access to liboctopus and open-design-text-renderer
-          # https://github.com/organizations/opendesigndev/settings/personal-access-tokens/39049
-          token: ${{ secrets.ODE_REPOS_TOKEN }}
           submodules: true
       - uses: ./.github/actions/determine-version
         with:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -16,9 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          # Personal token with read-only access to liboctopus and open-design-text-renderer
-          # https://github.com/organizations/opendesigndev/settings/personal-access-tokens/39049
-          token: ${{ secrets.ODE_REPOS_TOKEN }}
           submodules: recursive
       - uses: ./.github/actions/determine-version
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,9 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          # Personal token with read-only access to liboctopus and open-design-text-renderer
-          # https://github.com/organizations/opendesigndev/settings/personal-access-tokens/39049
-          token: ${{ secrets.ODE_REPOS_TOKEN }}
           submodules: true
 
       - name: Get project variables


### PR DESCRIPTION
All used repos are now public so we don't need a token anymore.